### PR TITLE
Setting _scores attribute

### DIFF
--- a/naive_feature_selection/naive_feature_selection.py
+++ b/naive_feature_selection/naive_feature_selection.py
@@ -283,17 +283,15 @@ class NaiveFeatureSelection(BaseEstimator, SelectorMixin):
         self._check_params(X, y)
 
         # Get features
-        if self.k == 0:
-            mask = np.zeros(X.shape[1], dtype=bool)
+        mask = np.zeros(X.shape[1], dtype=bool)
+        if self.k == 0 or self.k == "all":
             scores = np.zeros(X.shape[1], dtype=bool)
         elif self._is_binary(X):
             res_nfs = self._binary_naive_feature_selection(X, y, self.k)
-            mask = np.zeros(X.shape[1], dtype=bool)
             mask[res_nfs["idx"]] = 1
             scores = np.square(res_nfs["w"])
         else:
             res_nfs = self._naive_feature_selection(X, y, self.k)
-            mask = np.zeros(X.shape[1], dtype=bool)
             mask[res_nfs["idx"]] = 1
             scores = np.square(res_nfs["w"])
 

--- a/naive_feature_selection/naive_feature_selection.py
+++ b/naive_feature_selection/naive_feature_selection.py
@@ -283,25 +283,27 @@ class NaiveFeatureSelection(BaseEstimator, SelectorMixin):
         self._check_params(X, y)
 
         # Get features
-        if self.k == "all":
-            mask = np.ones(X.shape[1], dtype=bool)
-        elif self.k == 0:
+        if self.k == 0:
             mask = np.zeros(X.shape[1], dtype=bool)
+            scores = np.zeros(X.shape[1], dtype=bool)
         elif self._is_binary(X):
             res_nfs = self._binary_naive_feature_selection(X, y, self.k)
             mask = np.zeros(X.shape[1], dtype=bool)
             mask[res_nfs["idx"]] = 1
+            scores = np.square(res_nfs["w"])
         else:
             res_nfs = self._naive_feature_selection(X, y, self.k)
             mask = np.zeros(X.shape[1], dtype=bool)
             mask[res_nfs["idx"]] = 1
+            scores = np.square(res_nfs["w"])
 
         self.mask_ = mask
+        self.scores_ = scores
         return self
 
 
     def _get_support_mask(self):
-        check_is_fitted(self, "mask_")
+        check_is_fitted(self)
         return self.mask_
 
 

--- a/naive_feature_selection/naive_feature_selection.py
+++ b/naive_feature_selection/naive_feature_selection.py
@@ -285,6 +285,8 @@ class NaiveFeatureSelection(BaseEstimator, SelectorMixin):
         # Get features
         mask = np.zeros(X.shape[1], dtype=bool)
         scores = None
+        if self.k == "all":
+            mask = np.ones(X.shape[1], dtype=bool)
         elif self._is_binary(X):
             res_nfs = self._binary_naive_feature_selection(X, y, self.k)
             mask[res_nfs["idx"]] = 1

--- a/naive_feature_selection/naive_feature_selection.py
+++ b/naive_feature_selection/naive_feature_selection.py
@@ -284,8 +284,7 @@ class NaiveFeatureSelection(BaseEstimator, SelectorMixin):
 
         # Get features
         mask = np.zeros(X.shape[1], dtype=bool)
-        if self.k == 0 or self.k == "all":
-            scores = np.zeros(X.shape[1], dtype=bool)
+        scores = None
         elif self._is_binary(X):
             res_nfs = self._binary_naive_feature_selection(X, y, self.k)
             mask[res_nfs["idx"]] = 1
@@ -296,7 +295,8 @@ class NaiveFeatureSelection(BaseEstimator, SelectorMixin):
             scores = np.square(res_nfs["w"])
 
         self.mask_ = mask
-        self.scores_ = scores
+        if scores is not None:
+            self.scores_ = scores
         return self
 
 


### PR DESCRIPTION
Attributes ```_scores``` to selected features based on the algorithm's result. Only performs attribution when the feature selection algorithm is executed (unless ```k``` is ```0``` or ```"all"```).

Note: the[ change in `check_is_fitted`](https://github.com/aspremon/NaiveFeatureSelection/compare/master...jotapem:master#diff-d8604bb4c0c37b694b51f1f79bf33fac8de6dd61278a3964186251935659c421R304) is probably due to updates in the scikit-learn API.